### PR TITLE
Fix escaping double-quote

### DIFF
--- a/asterisk/agi.py
+++ b/asterisk/agi.py
@@ -85,7 +85,7 @@ class AGI:
         self.stderr.write('\n')
 
     def _quote(self, string):
-        return ''.join(['"', str(string), '"'])
+        return ''.join(['"', str(string).replace('"', '\\"'), '"'])
 
     def _handle_sighup(self, signum, frame):
         """Handle the SIGHUP signal"""


### PR DESCRIPTION
When escaping string, we have to escape double-quote by adding a backslash before them.

Example of error produce without this patch:
```
Asterisk AGI:     COMMAND: SET VARIABLE "TICKETSUBJECT" "Test with "double-quote""

Asterisk AGI:     RESULT_LINE: 520-Invalid command syntax.  Proper usage follows:

Traceback (most recent call last):
  File "/usr/local/src/asterisk-scripts/peephone/scripts/ticket_update.py", line 158, in main
    agi.set_variable("TICKETSUBJECT", ticket["Subject"])
  File "/usr/local/src/asterisk-scripts/peephone/asterisk.py", line 120, in set_variable
    self._agi.set_variable(varname, value)
  File "/usr/local/src/asterisk-scripts/venv/lib/python3.9/site-packages/asterisk/agi.py", line 526, in set_variable
    self.execute('SET VARIABLE', self._quote(name), self._quote(value))
  File "/usr/local/src/asterisk-scripts/venv/lib/python3.9/site-packages/asterisk/agi.py", line 104, in execute
    return self.get_result()
  File "/usr/local/src/asterisk-scripts/venv/lib/python3.9/site-packages/asterisk/agi.py", line 157, in get_result
    raise AGIUsageError(usage)
asterisk.agi.AGIUsageError: 520-Invalid command syntax.  Proper usage follows:
Sets a variable to the current channel.
520 End of proper usage.
```